### PR TITLE
Update NumberControl.php

### DIFF
--- a/src/NumberControl.php
+++ b/src/NumberControl.php
@@ -9,6 +9,7 @@
 
 namespace kartik\number;
 
+use yii;
 use yii\helpers\ArrayHelper;
 use yii\helpers\Html;
 use kartik\base\InputWidget;


### PR DESCRIPTION
Error in line 94: $formatter = Yii::$app->formatter;
Include yii on the head of file.

## Scope
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

## Changes
The following changes were made (this change is also documented in the [change log](https://github.com/kartik-v/yii2-number/blob/master/CHANGE.md)):

- Add line "use yii;"
-
-

## Related Issues
If this is related to an existing ticket, include a link to it as well.